### PR TITLE
Hide badges on the Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+<!-- statamic:hide -->
+
 ![Statamic](https://flat.badgen.net/badge/Statamic/3.1+/FF269E)
 ![Packagist version](https://flat.badgen.net/packagist/v/jacksleight/lazy-logo)
 ![License](https://flat.badgen.net/github/license/jacksleight/lazy-logo)
+
+<!-- /statamic:hide -->
 
 # Lazy Logo 
 


### PR DESCRIPTION
This pull request will hide the badges in the `README` from the Statamic Marketplace page, while keeping them showing on GitHub.

(I know this is unsolicited so feel free to not merge if you don't want to)