### PR TITLE
Disable auth for this route

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -1,3 +1,3 @@
 <?php
 
-Route::get('lazy-logo.svg', 'CP\LogoController');
+Route::get('lazy-logo.svg', 'CP\LogoController')->withoutMiddleware(['statamic.cp.authenticated']);


### PR DESCRIPTION
We do not want auth check on this route since it will be used in login form.

I was using a custom name for my control panel (hq) and noticed that the logo only worked when logged in. Disabled the auth middleware and the logo was showing in the login form aswell :-)